### PR TITLE
fix(stt): add missing `|| true` to SessionStart hook

### DIFF
--- a/stt/hooks/hooks.json
+++ b/stt/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/exec.py -m elevenlabs_stt.daemon start --background 2>/dev/null || python ${CLAUDE_PLUGIN_ROOT}/scripts/exec.py -m elevenlabs_stt.daemon start --background",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/exec.py -m elevenlabs_stt.daemon start --background 2>/dev/null || python ${CLAUDE_PLUGIN_ROOT}/scripts/exec.py -m elevenlabs_stt.daemon start --background 2>/dev/null || true",
             "timeout": 5000
           }
         ]


### PR DESCRIPTION
## Summary

The STT plugin's `SessionStart` hook in `stt/hooks/hooks.json` is missing `2>/dev/null || true` at the end of its command, unlike the TTS plugin which has it. This causes Claude Code to display a startup hook error when the `elevenlabs_stt` module isn't installed or the daemon fails to start.

**Before:**
```
python3 ... start --background 2>/dev/null || python ... start --background
```

**After:**
```
python3 ... start --background 2>/dev/null || python ... start --background 2>/dev/null || true
```

This matches the pattern already used by the TTS plugin's `SessionStart` and `Stop` hooks (see `tts/hooks/hooks.json`).

Fixes #2

## Change

One-line change in `stt/hooks/hooks.json`: append `2>/dev/null || true` to the SessionStart command so that the hook always exits with code 0, even when the STT daemon isn't available.