### PR TITLE
fix(stt): filter None values in config.save() to fix silent TOML serialization failure

### DIFF
--- a/stt/src/elevenlabs_stt/config.py
+++ b/stt/src/elevenlabs_stt/config.py
@@ -151,23 +151,22 @@ class Config(BaseModel):
         config_path = self.get_config_path()
         config_path.parent.mkdir(parents=True, exist_ok=True)
 
-        data = {
-            "elevenlabs-stt": {
-                "api_key": self.api_key,
-                "model_id": self.model_id,
-                "language_code": self.language_code,
-                "hotkey": self.hotkey,
-                "activation_mode": self.activation_mode,
-                "transcription_mode": self.transcription_mode,
-                "sample_rate": self.sample_rate,
-                "max_recording_seconds": self.max_recording_seconds,
-                "input_device": self.input_device,
-                "output_mode": self.output_mode,
-                "sound_effects": self.sound_effects,
-                "streaming_vad_mode": self.streaming_vad_mode,
-                "streaming_vad_silence_secs": self.streaming_vad_silence_secs,
-            }
+        fields = {
+            "api_key": self.api_key,
+            "model_id": self.model_id,
+            "language_code": self.language_code,
+            "hotkey": self.hotkey,
+            "activation_mode": self.activation_mode,
+            "transcription_mode": self.transcription_mode,
+            "sample_rate": self.sample_rate,
+            "max_recording_seconds": self.max_recording_seconds,
+            "input_device": self.input_device,
+            "output_mode": self.output_mode,
+            "sound_effects": self.sound_effects,
+            "streaming_vad_mode": self.streaming_vad_mode,
+            "streaming_vad_silence_secs": self.streaming_vad_silence_secs,
         }
+        data = {"elevenlabs-stt": {k: v for k, v in fields.items() if v is not None}}
 
         temp_file = None
         try:


### PR DESCRIPTION
## Summary

`Config.save()` silently fails (returns `False`) for every user with default settings because the `input_device` field defaults to `None`, and TOML has no null type.

When `tomli_w.dump()` encounters `None` in the data dict, it raises a `TypeError`. This exception is swallowed by the bare `except Exception: return False` block, so the failure is completely silent — no config file is ever written after a fresh install.

## Root Cause

In `stt/src/elevenlabs_stt/config.py`, the `save()` method constructs the TOML data dict with all fields unconditionally:

```python
data = {
    "elevenlabs-stt": {
        ...
        "input_device": self.input_device,  # None by default
        ...
    }
}
```

`tomli_w` faithfully follows the TOML spec, which has no null/None type, so `dump()` raises `TypeError`.

## Fix

Filter out `None` values before passing the dict to `tomli_w.dump()`:

```python
fields = {
    "api_key": self.api_key,
    ...
    "input_device": self.input_device,
    ...
}
data = {"elevenlabs-stt": {k: v for k, v in fields.items() if v is not None}}
```

When `input_device` is explicitly set to a device name (a string), it is included normally. When it is `None` (the default), it is simply omitted from the TOML file — and `load()` already handles missing keys correctly by using the Pydantic field defaults.

## Test plan

- [ ] Fresh install: `Config().save()` returns `True` and writes a valid `config.toml`
- [ ] With `input_device` set to a string: field appears in saved TOML
- [ ] With `input_device` as `None` (default): field is omitted, `load()` still returns `input_device=None`
- [ ] Round-trip: `save()` then `load()` preserves all non-None settings

Fixes #3